### PR TITLE
Fix demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Explore the depths of an ancient dungeon in the first streamlit-based dungeon cr
 
 Streamlit recalculates whole app in response to user input. This feature can be used to create interactive applications, such as a dungeon crawler game, where the user interacts with the page and the page updates in real-time to reflect the changes.
 
-[dungeon.streamlit.app](https://dunegon.streamlit.app)
+[dungeon.streamlit.app](https://dungeon.streamlit.app)
 
 **Change log:**
 


### PR DESCRIPTION
typo found:
> https://dunegon.streamlit.app
replaced by:
> https://dungeon.streamlit.app

Nice work although control of the game is quite slow when using the streamlit-hosted demo version!